### PR TITLE
fixed link on team page

### DIFF
--- a/Team.md
+++ b/Team.md
@@ -14,6 +14,6 @@
 
 ### Project Leads
 
-* [Untangle](/untangle/) - Quinn Gieseke
+* [Untangle](/untangle) - Quinn Gieseke
 
-* [City-Virtual](/city-virtual/) - Anar Kazimov
+* [City-Virtual](/city-virtual) - Anar Kazimov


### PR DESCRIPTION
Sorry, missed one link, Untangle on team page had a rouge slash. The city-virtual had the same problem, but worked fine? Ill have to look more into it.